### PR TITLE
Stop Clear-Water from running on server side

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -17,10 +17,9 @@
   "icon": "icon.png",
   "environment": "*",
   "entrypoints": {
-    "main": [
-      "koala.clearwater.fabric.ClearWaterFabric"
-    ],
+    "main": [],
     "client": [
+      "koala.clearwater.fabric.ClearWaterFabric"
     ],
     "modmenu": [
       "koala.clearwater.fabric.ModMenuIntegration"

--- a/neoforge/src/main/resources/META-INF/mods.toml
+++ b/neoforge/src/main/resources/META-INF/mods.toml
@@ -19,18 +19,18 @@ modId = "neoforge"
 type = "required"
 versionRange = "[20.4,)"
 ordering = "NONE"
-side = "BOTH"
+side = "CLIENT"
 
 [[dependencies.clearwater]]
 modId = "resourcefulconfig"
 type = "required"
 versionRange = "[2.4.3,)"
 ordering = "NONE"
-side = "BOTH"
+side = "CLIENT"
 
 [[dependencies.clearwater]]
 modId = "minecraft"
 type = "required"
 versionRange = "[1.20,)"
 ordering = "NONE"
-side = "BOTH"
+side = "CLIENT"


### PR DESCRIPTION
this PR edit manifest files of fabric and neoforge to stop the mod from being run on server and causing crashes because of missing rendering related class

fixes following issues:
#5 #6 